### PR TITLE
Autocontinue drills

### DIFF
--- a/__tests__/stopcovid/drill_progress/test_status.py
+++ b/__tests__/stopcovid/drill_progress/test_status.py
@@ -1,22 +1,40 @@
 import logging
 import unittest
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 from stopcovid.dialog.models.events import (
     DrillStarted,
     UserValidated,
     NextDrillRequested,
     DialogEventBatch,
+    DrillCompleted,
 )
 from stopcovid.dialog.registration import CodeValidationPayload
-from stopcovid.dialog.models.state import UserProfile
+from stopcovid.dialog.models.state import UserProfile, DialogState
 from stopcovid.drills.drills import get_drill
-from stopcovid.drill_progress.status import initiates_first_drill, initiates_subsequent_drill
+from stopcovid.drill_progress.status import (
+    initiates_first_drill,
+    initiates_subsequent_drill,
+)
 
 
 class TestStatus(unittest.TestCase):
     def setUp(self) -> None:
         logging.disable(logging.CRITICAL)
-        self.drill = get_drill("01-sample-drill")
+        self.phone_number = "123456789"
+        self.first_drill = get_drill("01-sample-drill")
+        self.intake_drill = get_drill("00-intake")
+        self.repo = MagicMock()
+        self.repo_1 = MagicMock()
+        self.dialog_state = DialogState(
+            current_drill=self.intake_drill, phone_number=self.phone_number, seq="0"
+        )
+        self.repo.fetch_dialog_state = MagicMock(return_value=self.dialog_state)
+        self.dialog_state_1 = DialogState(
+            current_drill=self.first_drill, phone_number=self.phone_number, seq="0"
+        )
+        self.repo_1.fetch_dialog_state = MagicMock(return_value=self.dialog_state_1)
 
     def test_initiates_first_drill(self):
         batch1 = DialogEventBatch(
@@ -31,8 +49,8 @@ class TestStatus(unittest.TestCase):
                 DrillStarted(
                     phone_number="123456789",
                     user_profile=UserProfile(True),
-                    drill=self.drill,
-                    first_prompt=self.drill.prompts[0],
+                    drill=self.first_drill,
+                    first_prompt=self.first_drill.prompts[0],
                 ),
             ],
         )
@@ -43,8 +61,8 @@ class TestStatus(unittest.TestCase):
                 DrillStarted(
                     phone_number="987654321",
                     user_profile=UserProfile(True),
-                    drill=self.drill,
-                    first_prompt=self.drill.prompts[0],
+                    drill=self.first_drill,
+                    first_prompt=self.first_drill.prompts[0],
                 )
             ],
         )
@@ -64,8 +82,8 @@ class TestStatus(unittest.TestCase):
                 DrillStarted(
                     phone_number="123456789",
                     user_profile=UserProfile(True),
-                    drill=self.drill,
-                    first_prompt=self.drill.prompts[0],
+                    drill=self.first_drill,
+                    first_prompt=self.first_drill.prompts[0],
                 ),
             ],
         )
@@ -76,10 +94,49 @@ class TestStatus(unittest.TestCase):
                 DrillStarted(
                     phone_number="987654321",
                     user_profile=UserProfile(True),
-                    drill=self.drill,
-                    first_prompt=self.drill.prompts[0],
+                    drill=self.first_drill,
+                    first_prompt=self.first_drill.prompts[0],
                 )
             ],
         )
-        self.assertTrue(initiates_subsequent_drill(batch1))
-        self.assertFalse(initiates_subsequent_drill(batch2))
+        self.assertTrue(initiates_subsequent_drill(batch1, self.repo))
+        self.assertFalse(initiates_subsequent_drill(batch2, self.repo))
+
+    def test_autocontinue_next_drill(self):
+        batch1 = DialogEventBatch(
+            phone_number="123456789",
+            seq="0",
+            events=[
+                DrillCompleted(
+                    drill_instance_id=uuid4(),
+                    phone_number="123456789",
+                    user_profile=UserProfile(True),
+                )
+            ],
+        )
+        batch2 = DialogEventBatch(
+            phone_number="123456789",
+            seq="0",
+            events=[
+                DrillCompleted(
+                    drill_instance_id=uuid4(),
+                    phone_number="123456789",
+                    user_profile=UserProfile(True),
+                )
+            ],
+        )
+        batch3 = DialogEventBatch(
+            phone_number="987654321",
+            seq="1",
+            events=[
+                DrillStarted(
+                    phone_number="987654321",
+                    user_profile=UserProfile(True),
+                    drill=self.intake_drill,
+                    first_prompt=self.intake_drill.prompts[0],
+                )
+            ],
+        )
+        self.assertTrue(initiates_subsequent_drill(batch1, self.repo))
+        self.assertFalse(initiates_subsequent_drill(batch2, self.repo_1))
+        self.assertFalse(initiates_subsequent_drill(batch3, self.repo))

--- a/__tests__/stopcovid/drill_progress/test_status.py
+++ b/__tests__/stopcovid/drill_progress/test_status.py
@@ -106,8 +106,12 @@ class TestStatus(unittest.TestCase):
                 )
             ],
         )
-        self.assertTrue(initiates_subsequent_drill(batch1, self.repo))
-        self.assertFalse(initiates_subsequent_drill(batch2, self.repo))
+        self.assertTrue(
+            initiates_subsequent_drill(batch1, self.repo.fetch_dialog_state(batch1.phone_number))
+        )
+        self.assertFalse(
+            initiates_subsequent_drill(batch2, self.repo.fetch_dialog_state(batch2.phone_number))
+        )
 
     def test_autocontinue_next_drill(self):
         batch1 = DialogEventBatch(
@@ -144,6 +148,12 @@ class TestStatus(unittest.TestCase):
                 )
             ],
         )
-        self.assertTrue(initiates_subsequent_drill(batch1, self.repo))
-        self.assertFalse(initiates_subsequent_drill(batch2, self.repo))
-        self.assertFalse(initiates_subsequent_drill(batch3, self.repo))
+        self.assertTrue(
+            initiates_subsequent_drill(batch1, self.repo.fetch_dialog_state(batch1.phone_number))
+        )
+        self.assertFalse(
+            initiates_subsequent_drill(batch2, self.repo.fetch_dialog_state(batch2.phone_number))
+        )
+        self.assertFalse(
+            initiates_subsequent_drill(batch3, self.repo.fetch_dialog_state(batch3.phone_number))
+        )

--- a/__tests__/stopcovid/sms/test_enqueue_outbound_sms.py
+++ b/__tests__/stopcovid/sms/test_enqueue_outbound_sms.py
@@ -192,7 +192,7 @@ class TestPublishOutboundSMS(unittest.TestCase):
         send_messages_mock.assert_called_once()
         call = send_messages_mock.mock_calls[0]
         _, *kwargs = call
-        return kwargs[1]["Entries"]
+        return kwargs[1]["Entries"]  # type: ignore
 
     def test_no_messages(self, boto_mock):
         send_messages_mock = self._get_mocked_send_messages(boto_mock)

--- a/stopcovid/drill_progress/status.py
+++ b/stopcovid/drill_progress/status.py
@@ -32,11 +32,11 @@ def initiates_first_drill(batch: DialogEventBatch):
 
 
 def initiates_subsequent_drill(batch: DialogEventBatch, repo: DialogRepository):
+    dialog_state = repo.fetch_dialog_state(batch.phone_number)
     for event in batch.events:
         if isinstance(event, NextDrillRequested):
             return True
         elif isinstance(event, DrillCompleted):
-            dialog_state = repo.fetch_dialog_state(batch.phone_number)
             current_drill = dialog_state.current_drill
             if current_drill.auto_continue:
                 return True

--- a/stopcovid/drill_progress/status.py
+++ b/stopcovid/drill_progress/status.py
@@ -2,7 +2,13 @@ from typing import List
 
 from .initiation import DrillInitiator
 from .drill_progress import DrillProgressRepository
-from ..dialog.models.events import UserValidated, NextDrillRequested, DialogEventBatch
+from ..dialog.persistence import DialogRepository, DynamoDBDialogRepository
+from ..dialog.models.events import (
+    UserValidated,
+    NextDrillRequested,
+    DialogEventBatch,
+    DrillCompleted,
+)
 
 
 def handle_dialog_event_batches(batches: List[DialogEventBatch]):
@@ -14,9 +20,10 @@ def handle_dialog_event_batches(batches: List[DialogEventBatch]):
             initiator.trigger_first_drill(batch.phone_number, str(batch.batch_id))
 
     user_repo = DrillProgressRepository()
+    state_repo = DynamoDBDialogRepository()
     for batch in batches:
         user_repo.update_user(batch)
-        if initiates_subsequent_drill(batch):
+        if initiates_subsequent_drill(batch, state_repo):
             initiator.trigger_next_drill_for_user(batch.phone_number, str(batch.batch_id))
 
 
@@ -24,5 +31,12 @@ def initiates_first_drill(batch: DialogEventBatch):
     return any(event for event in batch.events if isinstance(event, UserValidated))
 
 
-def initiates_subsequent_drill(batch: DialogEventBatch):
-    return any(event for event in batch.events if isinstance(event, NextDrillRequested))
+def initiates_subsequent_drill(batch: DialogEventBatch, repo: DialogRepository):
+    for event in batch.events:
+        if isinstance(event, NextDrillRequested):
+            return True
+        elif isinstance(event, DrillCompleted):
+            dialog_state = repo.fetch_dialog_state(batch.phone_number)
+            current_drill = dialog_state.current_drill
+            if current_drill.auto_continue:
+                return True

--- a/stopcovid/drills/drill_content/drills.json
+++ b/stopcovid/drills/drill_content/drills.json
@@ -1,7 +1,8 @@
 {
-  "01-sample-drill": {
-    "name": "Sample Drill 1",
-    "slug": "01-sample-drill",
+  "00-intake": {
+    "name": "Intake",
+    "slug": "00-intake",
+    "auto_continue": true,
     "prompts": [
       {
         "slug": "1 -",
@@ -12,6 +13,20 @@
         ],
         "response_user_profile_key": "language"
       },
+      {
+        "slug": "2 -",
+        "messages": [
+          {
+            "text": "{{sms_disclaimer}}"
+          }
+        ]
+      }
+    ]
+  },
+  "01-sample-drill": {
+    "name": "Sample Drill 1",
+    "slug": "01-sample-drill",
+    "prompts": [
       {
         "slug": "2 -",
         "messages": [

--- a/stopcovid/drills/drill_content/translations.json
+++ b/stopcovid/drills/drill_content/translations.json
@@ -1,6 +1,16 @@
 {
   "instructions": [
     {
+      "label": "sms_disclaimer",
+      "translation": "Message and data rates apply. Reply STOP to unsubscribe.",
+      "language": "en"
+    },
+    {
+      "label": "sms_disclaimer",
+      "translation": "Se aplican tarifas de mensajes y datos. Responda STOP para cancelar la suscripción.",
+      "language": "es"
+    },
+    {
       "label": "corrected_answer",
       "translation": "🤖 The correct answer is *{{correct_answer}}*.\n\nLets move to the next one.",
       "language": "en"

--- a/stopcovid/drills/drills.py
+++ b/stopcovid/drills/drills.py
@@ -57,6 +57,7 @@ class Prompt:
 class DrillSchema(Schema):
     name = fields.String(required=True)
     slug = fields.String(required=True)
+    auto_continue = fields.Boolean(required=False)
     prompts = fields.List(fields.Nested(PromptSchema), required=True)
 
     @post_load
@@ -69,6 +70,7 @@ class Drill:
     slug: str
     name: str
     prompts: List[Prompt]
+    auto_continue: Optional[bool] = False
 
     def first_prompt(self) -> Prompt:
         return self.prompts[0]


### PR DESCRIPTION
This adds an optional auto_continue flag to drills to indicate that at the end of the drill, the user should automatically be advanced to the next drill.