### PR TITLE
Allow none in marshmallow schema for loading failed prompt

### DIFF
--- a/__tests__/stopcovid/sms/test_enqueue_outbound_sms.py
+++ b/__tests__/stopcovid/sms/test_enqueue_outbound_sms.py
@@ -116,7 +116,6 @@ class TestHandleCommand(unittest.TestCase):
         self.assertEqual(message.body, localize(CORRECT_ANSWER_COPY, "en", emojis=""))
 
     def test_abandoned_failed_prompt_event(self):
-
         dialog_events: List[DialogEvent] = [
             FailedPrompt(
                 self.phone,

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -228,7 +228,7 @@ class CompletedPrompt(DialogEvent):
 class FailedPromptSchema(DialogEventSchema):
     prompt = fields.Nested(drills.PromptSchema, required=True)
     abandoned = fields.Boolean(required=True)
-    response = fields.String(required=True)
+    response = fields.String(required=True, allow_none=True)
     drill_instance_id = fields.UUID(required=True)
 
     @post_load


### PR DESCRIPTION
#8 caused the event distributor to choke in dev as it needs to deserialize failed prompts with null responses