### PR TITLE
Fixed localizations

### DIFF
--- a/stopcovid/drills/localize.py
+++ b/stopcovid/drills/localize.py
@@ -11,8 +11,10 @@ def localize(message: str, lang: Optional[str], **kwargs) -> str:
     lang = lang.lower()
     if lang not in SUPPORTED_LANGUAGES:
         lang = "en"
+
     template = Template(message)
-    result = template.render(**localizations_for(lang))
+    result = template.render({**kwargs, **localizations_for(lang)})
+
     if kwargs:
         template = Template(result)
         result = template.render(**kwargs)

--- a/stopcovid/sms/enqueue_outbound_sms.py
+++ b/stopcovid/sms/enqueue_outbound_sms.py
@@ -48,7 +48,7 @@ def get_localized_messages(
     language = dialog_event.user_profile.language
 
     additional_args = {
-        "company": dialog_event.user_profile.account_info.get("company", "your company"),
+        "company": dialog_event.user_profile.account_info.get("employer_name", "your company"),
         "name": "",
     }
     if dialog_event.user_profile.name is not None:


### PR DESCRIPTION
This fixes two problems with localizations:
- It was trying to get company name from "company" instead of "employer_name" within user profile
- "name" and "company" only worked if they were contained within a translation. This allows them to work within a drill directly which might already exist but likely to happen in the future.