### PR TITLE
Forward dialog event batches to kinesis

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -200,6 +200,13 @@ resources:
         Name: message-log-${self:provider.stage}
         ShardCount: 2
 
+    # DIALOG EVENT BATCHES STREAM
+    DialogEventBatchesStream:
+      Type: AWS::Kinesis::Stream
+      Properties:
+        Name: dialog-event-batches-${self:provider.stage}
+        ShardCount: 2
+
     WriteMessageEvent:
       Type: AWS::Lambda::EventSourceMapping
       Properties:


### PR DESCRIPTION
Two main reasons for doing this:
1) Reading from a dynamo stream is a pain. AWS offers a [Dynamo Stream Adapter](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.KCLAdapter.html) for the Kinesis Client Library that looks like a disaster. It's the thing that requires the MultiLangDaemon because it runs in java. 
2) AWS recommends only two consumers of dynamo db streams at a given time, or else you face rate limiting. This limitation will make transitioning to the new drill progress app much more difficult

Once the new drill progress app is 1:1 with the existing system, we can repurpose this lambda to only write to kinesis. 