### PR TITLE
Allow none for drill instance id in opted out event

### DIFF
--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -336,7 +336,7 @@ class DrillCompleted(DialogEvent):
 
 
 class OptedOutSchema(DialogEventSchema):
-    drill_instance_id = fields.UUID()
+    drill_instance_id = fields.UUID(allow_none=True)
 
     @post_load
     def make_opted_out(self, data, **kwargs):


### PR DESCRIPTION
The event beneath it doesnt require the drill instance id but the schema does. This is only possible when you opt out _after_ opting out already 🤯 